### PR TITLE
BSD fixes + last missing manpage

### DIFF
--- a/software/usb_ir/CMakeLists.txt
+++ b/software/usb_ir/CMakeLists.txt
@@ -53,6 +53,10 @@ If(TARGET_ANDROID)
 
 EndIf()
 
+include(CheckIncludeFile)
+set(CMAKE_REQUIRED_FLAGS "-I/usr/include")
+CHECK_INCLUDE_FILE("limits.h" HAVE_SYSLIMITS_H)
+CHECK_INCLUDE_FILE("libusb-1.0/libusb.h" HAVE_USB_10_LIBUSB_H)
 include(CheckFunctionExists)
 
 # default the LIBDIR if it was not set
@@ -85,16 +89,16 @@ ElseIf("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
         string(REGEX REPLACE "\n$" "" UDEVDIR ${UDEVDIR})
         string(STRIP UDEVDIR ${UDEVDIR})
     else()
-        set(UDEVDIR "/lib/udev")
+        set(UDEVDIR "")
     endif()
     pkg_check_modules(SYSTEMD systemd)
     if ("${SYSTEMD_FOUND}" EQUAL 1)
         execute_process(COMMAND pkg-config --variable systemdsystemunitdir systemd
-        OUTPUT_VARIABLE SYSTEMD_UNITDIR)
+                        OUTPUT_VARIABLE SYSTEMD_UNITDIR)
         string(REGEX REPLACE "\n$" "" SYSTEMD_UNITDIR ${SYSTEMD_UNITDIR})
         string(STRIP SYSTEMD_UNITDIR ${SYSTEMD_UNITDIR})
         execute_process(COMMAND pkg-config --variable tmpfilesdir systemd
-        OUTPUT_VARIABLE TMPFILESDIR)
+                        OUTPUT_VARIABLE TMPFILESDIR)
         string(REGEX REPLACE "\n$" "" TMPFILESDIR ${TMPFILESDIR})
         string(STRIP TMPFILESDIR ${TMPFILESDIR})
     endif()
@@ -121,8 +125,20 @@ ElseIf("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     If(NOT TARGET_ANDROID)
       List(APPEND BASELIBS rt)
     EndIf()
+ElseIf("${CMAKE_SYSTEM_NAME}" MATCHES "BSD")
+    # see if we have clock_gettime in time.h
+    Set(CMAKE_REQUIRED_LIBRARIES rt)
+    check_function_exists(clock_gettime USE_CLOCK_GETTIME)
+    Unset(CMAKE_REQUIRED_LIBRARIES)
+    List(APPEND BASESRC compat-unix.c)
+    Set(PIPESRC pipes.c)
+    Set(DAEMONSRC daemon.c)
+    Set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O2 -Wall -pedantic -I/usr/local/include")
+    Set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/local/lib")
+    Set(ARGPLIB "-largp")
+    Set(PTHREADLIB "-lpthread")
 Else()
-	message(FATAL_ERROR "Unrecognized CMAKE_SYSTEM_NAME")
+    message(FATAL_ERROR "Unrecognized CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 EndIf()
 
 # let the user know what platform was detected
@@ -155,6 +171,8 @@ add_executable(igdaemon ${DAEMONSRC}
                list.c protocol-versions.c ${PIPESRC} dataPackets.c ${BASESRC})
 set_property(TARGET igdaemon
              APPEND PROPERTY COMPILE_DEFINITIONS SUPPORT_EXPORTS)
+set_property(TARGET igdaemon
+             PROPERTY LINK_FLAGS  "${PTHREADLIB}")
 target_link_libraries(igdaemon iguanaIR
                                ${DAEMONLIBS} ${BASELIBS} ${ARGPLIB})
 install(TARGETS igdaemon DESTINATION /usr/bin)
@@ -167,6 +185,7 @@ add_subdirectory(drivers)
 add_executable(igclient client.c list.c ${BASESRC})
 set_property(TARGET igclient
              APPEND PROPERTY COMPILE_DEFINITIONS SUPPORT_EXPORTS)
+     set_property(TARGET igclient PROPERTY LINK_FLAGS "${ARGPLIB}")
 target_link_libraries(igclient iguanaIR ${BASELIBS} ${ARGPLIB})
 install(TARGETS igclient DESTINATION /usr/bin)
 
@@ -199,9 +218,9 @@ Else()
     include_directories(${PYTHON_INCLUDE_DIR} ${CMAKE_SOURCE_DIR})
     swig_add_module(iguanaIR python iguanaIR.i)
     swig_link_libraries(iguanaIR iguanaIR ${BASELIBS} ${PYTHON_LIBRARIES})
-	If(CMAKE_COMPILER_IS_GNUCC)
-      set_source_files_properties(${swig_generated_file_fullname}
-                                  PROPERTIES COMPILE_FLAGS "-Wno-long-long -Wno-unused-value")
+    If(CMAKE_COMPILER_IS_GNUCC)
+        set_source_files_properties(${swig_generated_file_fullname}
+        PROPERTIES COMPILE_FLAGS "-Wno-long-long -Wno-unused-value")
     EndIf()
 
     # install the python support
@@ -264,8 +283,10 @@ endif()
 install(DIRECTORY files/base/etc files/base/usr
         USE_SOURCE_PERMISSIONS
         DESTINATION /)
-install(DIRECTORY files/base/lib/udev/rules.d
+if ("${UDEV_FOUND}" EQUAL 1)
+    install(DIRECTORY files/base/lib/udev/rules.d
         DESTINATION ${UDEVDIR})
+endif()
 install(FILES iguanaIR.h
         DESTINATION /usr/include)
 if ("${SYSTEMD_FOUND}" EQUAL 1)

--- a/software/usb_ir/bootstrap/runCmake
+++ b/software/usb_ir/bootstrap/runCmake
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # remember where we come from
 SOURCE="${BASH_SOURCE[0]}"
@@ -21,7 +21,15 @@ fi
 BUILDDIR=build
 PYPATH=/usr/bin
 QTPATH=/usr/bin
-CMAKE=/usr/bin/cmake
+if test -x /usr/bin/cmake; then
+    CMAKE=/usr/bin/cmake
+elif test -x /usr/local/bin/cmake; then
+    CMAKE=/usr/local/bin/cmake
+else
+    echo "Cannot find cmake" >&2
+    exit 2
+fi
+
 
 # override the defaults w use settings
 if [ -e settings.txt ]; then

--- a/software/usb_ir/config.h.in
+++ b/software/usb_ir/config.h.in
@@ -1,2 +1,3 @@
 /* use the available clock_gettime */
 #cmakedefine USE_CLOCK_GETTIME 1
+#cmakedefine HAVE_USB_10_LIBUSB_H 1

--- a/software/usb_ir/drivers/CMakeLists.txt
+++ b/software/usb_ir/drivers/CMakeLists.txt
@@ -25,7 +25,12 @@ If(COMPILE_NEW)
   add_library(usb SHARED libusb.c ../list.c)
   set_property(TARGET usb
                APPEND PROPERTY COMPILE_DEFINITIONS DRIVER_EXPORTS)
-  target_link_libraries(usb -lusb-1.0 iguanaIR)
+  if("${HAVE_USB_10_LIBUSB_H}" EQUAL 1)
+      target_link_libraries(usb -lusb-1.0 iguanaIR)
+  else()
+      target_link_libraries(usb -lusb iguanaIR)
+  endif()
+
   install(TARGETS usb
           DESTINATION ${LIBDIR}/iguanaIR)
 EndIf()

--- a/software/usb_ir/drivers/libusb.c
+++ b/software/usb_ir/drivers/libusb.c
@@ -17,8 +17,17 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <string.h>
-#include <libusb-1.0/libusb.h>
 #include <errno.h>
+
+#ifdef HAVE_USB_10_LIBUSB_H
+#include <libusb-1.0/libusb.h>
+#else
+#include <libusb.h>
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 1024
+#endif
 
 #include "../pipes.h"
 #include "../support.h"

--- a/software/usb_ir/files/base/usr/share/man/man1/iguanaIR-reflasher.1
+++ b/software/usb_ir/files/base/usr/share/man/man1/iguanaIR-reflasher.1
@@ -1,0 +1,59 @@
+.TH IGUANAIR-REFLASHER "1" "February 2017" "iguanaIR-reflasher" "User Commands"
+.SH NAME
+iguanaIR-reflasher \- update firmware in IguanaWorks IR devices.
+.SH SYNOPSIS
+.B iguanaIR-reflasher
+[\fI\,options\/\fR]
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+show this help message and exit
+.TP
+\fB\-\-blank\-pages\fR
+Write blank pages around the code pages.
+.TP
+\fB\-\-dry\-run\fR
+Do not write any "dangerous" pages.
+.TP
+\fB\-\-force\fR
+Write the firmware no matter what.
+.TP
+\fB\-\-no\-ids\fR
+Skip the step of checking the id.
+.TP
+\fB\-\-flash\-multiple\fR
+Loop through flashing multiple devices.
+.TP
+\fB\-\-go\fR
+Do not wait for the user to read the warnings.
+.TP
+\fB\-t\fR TYPE, \fB\-\-type\fR=\fI\,TYPE\/\fR
+Specify the device type: u,l,h,s,p.
+.TP
+\fB\-\-version\fR=\fI\,0xVERSION\/\fR
+Specify a hexadecimal target version.
+.TP
+\fB\-\-body\fR=\fI\,FILE\/\fR
+Specify the file to read the body from.
+.TP
+\fB\-\-keep\-loader\fR
+Keep the loader currently flashed loader.
+.TP
+\fB\-\-loader\fR=\fI\,FILE\/\fR
+Specify the file to read the loader from.
+.TP
+\fB\-\-old\-firmware\fR=\fI\,FILE\/\fR
+Specify a file of old (monolithic) firmware.
+.TP
+\fB\-l\fR FILE, \fB\-\-log\-file\fR=\fI\,FILE\/\fR
+Specify a log to receive all messages.
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Decrease verbosity.
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Increase verbosity.
+.SH "SEE ALSO"
+.B igdaemon(8)
+.br
+.B igclient(1)

--- a/software/usb_ir/iguanaIR.c
+++ b/software/usb_ir/iguanaIR.c
@@ -22,6 +22,10 @@
 #include "support.h"
 #include "dataPackets.h"
 
+#ifndef PATH_MAX
+#define PATH_MAX 1024
+#endif
+
 IGUANAIR_API PIPE_PTR iguanaConnect_internal(const char *name, unsigned int protocol, bool checkVersion)
 {
     PIPE_PTR conn = INVALID_PIPE;

--- a/software/usb_ir/server.c
+++ b/software/usb_ir/server.c
@@ -11,7 +11,10 @@
  * See LICENSE for license details.
  */
 
-#include <malloc.h>
+#include <stdlib.h>
+#ifndef PATH_MAX
+#define PATH_MAX 1024
+#endif
 
 #include "iguanaIR.h"
 #include "compat.h"


### PR DESCRIPTION
The missing --help for rescan was my bad, now fixed and a manpage generated.

This code builds on BSD, but  is not tested. The compiler warningsn below looks valid and should IMHO be fixed.

    usr/home/mk/IguanaIR-1.1.2/software/usb_ir/daemon.c:71:20: warning:
          incompatible integer to pointer conversion passing 'int' to parameter of
          type 'pthread_t' (aka 'struct pthread *') [-Wint-conversion]
        triggerCommand(QUIT_TRIGGER);
                       ^~~~~~~~~~~~
    /usr/home/mk/IguanaIR-1.1.2/software/usb_ir/daemon.c:59:39: note: passing
          argument to parameter 'cmd' here
    static void triggerCommand(THREAD_PTR cmd)
                                          ^
    /usr/home/mk/IguanaIR-1.1.2/software/usb_ir/daemon.c:76:20: warning: expression
          which evaluates to zero treated as a null pointer constant of type
          'pthread_t' (aka 'struct pthread *') [-Wnon-literal-null-conversion]
        triggerCommand(SCAN_TRIGGER);
                       ^~~~~~~~~~~~
    /usr/home/mk/IguanaIR-1.1.2/software/usb_ir/daemon.c:253:29: warning:
          comparison between pointer and integer ('pthread_t'
          (aka 'struct pthread *') and 'int')
                else if (thread == QUIT_TRIGGER)
                         ~~~~~~ ^  ~~~~~~~~~~~~
    3 warnings generated.

