### PR TITLE
Use Simple type for systemd service

### DIFF
--- a/software/usb_ir/files/systemd/lib/systemd/system/iguanaIR.service
+++ b/software/usb_ir/files/systemd/lib/systemd/system/iguanaIR.service
@@ -2,14 +2,14 @@
 Description=Iguanaworks USB IR transceiver
 
 [Service]
-Type=forking
 User=iguanair
 Group=iguanair
 EnvironmentFile=/etc/default/iguanaIR
 ExecStart=/usr/bin/igdaemon $DRIVERS $OPTIONS \
                             --log-level=${LOGLEVEL} \
                             --send-timeout=${SENDTIMEOUT} \
-                            --receive-timeout=${RECEIVETIMEOUT}
+                            --receive-timeout=${RECEIVETIMEOUT} \
+                            --no-daemon
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd prefers to be able to manage the processes running underneath
it. While forking is supported, it's not the default. Since iguanair
already supports an attached flag, we might as well use it here.